### PR TITLE
PAP-1904 Add dotnet format action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,7 +7,7 @@ on:
         default: "6.0.x"
 
 jobs:
-  Test:
+  Format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        required: false
+        type: string
+        default: "6.0.x"
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      - name: Verify code formating 
+        shell: bash
+        run: |
+          dotnet format --verify-no-changes
+      


### PR DESCRIPTION
We (PAP team) want to use GitHub actions to verify code is formatted according to .editorgonfig rules.

We suggested that it would be better to add this workflow to the shared repository and reuse it later in our repos.

Hope it comes along with this repo initial purpose =)