### PR TITLE
feat: add resolve-image-repos to sam deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,7 @@ jobs:
           --resolve-s3 \
           --config-file ./samconfig.toml \
           --config-env ${{ needs.Account.outputs.environment }} \
+          --resolve-image-repos \
           --tags \
             'domain=${{ inputs.domain }} \
             team=${{ inputs.team }}'


### PR DESCRIPTION
The option --resolve-image-repos is needed to automatically resolve container image repositories when deploying lambda containers via sam deploy
