### PR TITLE
Add IAM validation for PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,8 +5,22 @@ on:
         required: false
         type: string
         default: "6.0.x"
+      CHECK_IAM:
+        type: boolean
+        default: true
 
 jobs:
+  Check-IAM:
+    if: ${{ inputs.CHECK_IAM }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3      
+    - name: Run validation
+      uses:  mathem-se/iam-template-analyzer@main
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: ${{ github.head_ref }} 
   Test:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # gh-workflows-dotnet
  
+### Pull requests
+
+Add the following file `.github/workflows/pull-request.yml` to your project with this content:
+
+```yaml
+name: Pull request
+on: [pull_request]
+
+jobs:
+  PR:
+    uses: mathem-se/gh-workflows-dotnet/.github/workflows/pr.yml@@main
+    with:
+      CHECK_IAM: false #if you don't want to check lint (defaults to true)
+```
+
+### Deploy to AWS with SAM
+
+Add the following file `.github/workflows/deploy.yml` to your project with this content:
+
+```yaml
+name: Deploy to AWS
+on:
+  push:
+    branches: [main, master, develop]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  Deploy:
+    uses: mathem-se/gh-workflows-dotnet/.github/workflows/deploy.yml@main
+    with:
+      domain: <repo name> #change value
+      team: <team name> #change value
+    secrets:
+      AWS_CICD_ACCOUNT: ${{ secrets.AWS_CICD_ACCOUNT }}
+      AWS_CICD_API_URL: ${{ secrets.AWS_CICD_API_URL }}
+      AWS_CICD_API_REGION: ${{ secrets.AWS_CICD_API_REGION }}
+```


### PR DESCRIPTION
- Does a workflow_call to mathem-se/iam-template-analyzer@main which steps through the template-file and find resources containing '*' and actions containing :*.
- Add these as comments to the PR since this is not least privilege permissions.
- Set `CHECK_IAM` to false to opt out from this validation.
- Also adds to DynamoDB table who acts on diff if a new resource is added.

Example below:

![image](https://github.com/mathem-se/gh-workflows-dotnet/assets/56074741/d913a5a6-a8e2-430b-ad74-f87d56890136)
